### PR TITLE
Set up continuous integration using GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Continuous integration
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-20.04
+    name: Linux (Release)
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qqq build-essential cmake ninja-build
+
+      - name: Build and install using CMake
+        env:
+          CMAKE_GENERATOR: Ninja
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build
+          sudo cmake --build build --target install
+
+      - name: Run the compiled and installed binary (smoke test)
+        run: |
+          godotpcktool --help
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: godotpcktool-linux-glibc2.31
+          path: build/src/godotpcktool


### PR DESCRIPTION
This adds continuous integration as well as continuous builds uploaded to GitHub Actions artifacts.

Since recent C++ features are used, I had to use Ubuntu 20.04 for building. Help is welcome to use Ubuntu 18.04 instead, as it will produce binaries compatible with older Linux distributions.