### PR TITLE
Add support for format version 0

### DIFF
--- a/src/pck/PckFile.cpp
+++ b/src/pck/PckFile.cpp
@@ -41,7 +41,7 @@ bool PckFile::Load()
     MinorGodotVersion = Read32();
     PatchGodotVersion = Read32();
 
-    if(FormatVersion > MAX_PCK_FORMAT_VERSION) {
+    if(FormatVersion > MAX_SUPPORTED_PCK_VERSION) {
         std::cout << "ERROR: pck is unsupported version: " << FormatVersion << "\n";
         return false;
     }

--- a/src/pck/PckFile.cpp
+++ b/src/pck/PckFile.cpp
@@ -34,15 +34,15 @@ bool PckFile::Load()
         return false;
     }
 
-    uint32_t version = Read32();
+    FormatVersion = Read32();
 
     // Godot engine version, we don't care about these
     MajorGodotVersion = Read32();
     MinorGodotVersion = Read32();
     PatchGodotVersion = Read32();
 
-    if(version != PCK_FORMAT_VERSION) {
-        std::cout << "ERROR: pck is unsupported version: " << version << "\n";
+    if(FormatVersion > MAX_PCK_FORMAT_VERSION) {
+        std::cout << "ERROR: pck is unsupported version: " << FormatVersion << "\n";
         return false;
     }
 
@@ -112,7 +112,7 @@ bool PckFile::Save()
     // Header
 
     Write32(PCK_HEADER_MAGIC);
-    Write32(PCK_FORMAT_VERSION);
+    Write32(FormatVersion);
 
     // Godot version
 

--- a/src/pck/PckFile.h
+++ b/src/pck/PckFile.h
@@ -16,7 +16,7 @@ namespace pcktool {
 constexpr uint32_t PCK_HEADER_MAGIC = 0x43504447;
 
 // Highest pck version supported by this tool
-constexpr int MAX_PCK_FORMAT_VERSION = 1;
+constexpr int MAX_SUPPORTED_PCK_VERSION = 1;
 
 //! \brief A single pck file object. Handles reading and writing
 //!

--- a/src/pck/PckFile.h
+++ b/src/pck/PckFile.h
@@ -15,7 +15,7 @@ namespace pcktool {
 // Pck magic
 constexpr uint32_t PCK_HEADER_MAGIC = 0x43504447;
 
-// Pck version
+// Highest pck version supported by this tool
 constexpr int MAX_PCK_FORMAT_VERSION = 1;
 
 //! \brief A single pck file object. Handles reading and writing

--- a/src/pck/PckFile.h
+++ b/src/pck/PckFile.h
@@ -102,7 +102,7 @@ private:
     // 0 = Godot 1.x, 2.x
     // 1 = Godot 3.x
     // 2 = Godot 4.x
-    uint32_t FormatVersion = 0;
+    uint32_t FormatVersion = 1;
 
     // Loaded version info from a pack
     uint32_t MajorGodotVersion = 0;

--- a/src/pck/PckFile.h
+++ b/src/pck/PckFile.h
@@ -16,7 +16,7 @@ namespace pcktool {
 constexpr uint32_t PCK_HEADER_MAGIC = 0x43504447;
 
 // Pck version
-constexpr int PCK_FORMAT_VERSION = 1;
+constexpr int MAX_PCK_FORMAT_VERSION = 1;
 
 //! \brief A single pck file object. Handles reading and writing
 //!
@@ -97,6 +97,12 @@ private:
     std::string Path;
     std::optional<std::fstream> File;
     std::optional<std::ifstream> DataReader;
+
+    // PCK Format version number
+    // 0 = Godot 1.x, 2.x
+    // 1 = Godot 3.x
+    // 2 = Godot 4.x
+    uint32_t FormatVersion = 0;
 
     // Loaded version info from a pack
     uint32_t MajorGodotVersion = 0;


### PR DESCRIPTION
Fixes #29

This is a rather simple fix, since there were no format changes between 0 and 1. Now, we just check to see if the version greater than the max supported version (currently 1), and store that in the PckFile object to save it later if necessary.