### PR TITLE
Support reading of Godot4 .pck files

### DIFF
--- a/src/pck/PckFile.cpp
+++ b/src/pck/PckFile.cpp
@@ -41,7 +41,7 @@ bool PckFile::Load()
     MinorGodotVersion = Read32();
     PatchGodotVersion = Read32();
 
-    if(FormatVersion > MAX_SUPPORTED_PCK_VERSION) {
+    if(FormatVersion > MAX_SUPPORTED_PCK_VERSION_LOAD) {
         std::cout << "ERROR: pck is unsupported version: " << FormatVersion << "\n";
         return false;
     }
@@ -112,6 +112,11 @@ bool PckFile::Load()
 // ------------------------------------ //
 bool PckFile::Save()
 {
+    if(FormatVersion > MAX_SUPPORTED_PCK_VERSION_SAVE) {
+        std::cout << "ERROR: cannot save pck version: " << FormatVersion << "\n";
+        return false;
+    }
+
     const auto tmpWrite = Path + ".write";
 
     File = std::fstream(tmpWrite, std::ios::trunc | std::ios::out | std::ios::binary);

--- a/src/pck/PckFile.h
+++ b/src/pck/PckFile.h
@@ -14,9 +14,10 @@ namespace pcktool {
 
 // Pck magic
 constexpr uint32_t PCK_HEADER_MAGIC = 0x43504447;
+constexpr uint32_t PACK_DIR_ENCRYPTED = 1;
 
 // Highest pck version supported by this tool
-constexpr int MAX_SUPPORTED_PCK_VERSION = 1;
+constexpr int MAX_SUPPORTED_PCK_VERSION = 2;
 
 //! \brief A single pck file object. Handles reading and writing
 //!
@@ -28,6 +29,7 @@ public:
         uint64_t Offset;
         uint64_t Size;
         std::array<uint8_t, 16> MD5 = {0};
+        uint32_t Flags = 0;
 
         std::function<std::string()> GetData;
     };
@@ -108,6 +110,9 @@ private:
     uint32_t MajorGodotVersion = 0;
     uint32_t MinorGodotVersion = 0;
     uint32_t PatchGodotVersion = 0;
+
+    uint32_t Flags = 0;
+    uint64_t FileOffsetBase = 0;
 
     //! Add trailing null bytes to the length of a path until it is a multiple of this size
     size_t PadPathsToMultipleWithNULLS = 4;

--- a/src/pck/PckFile.h
+++ b/src/pck/PckFile.h
@@ -17,7 +17,8 @@ constexpr uint32_t PCK_HEADER_MAGIC = 0x43504447;
 constexpr uint32_t PACK_DIR_ENCRYPTED = 1;
 
 // Highest pck version supported by this tool
-constexpr int MAX_SUPPORTED_PCK_VERSION = 2;
+constexpr int MAX_SUPPORTED_PCK_VERSION_LOAD = 2;
+constexpr int MAX_SUPPORTED_PCK_VERSION_SAVE = 1;
 
 //! \brief A single pck file object. Handles reading and writing
 //!


### PR DESCRIPTION
Implements reading of Godot 4 .pck files (i.e. PCK version 2).

Decryption is not implemented. An error is produced if the pack's flags indicate that the content is encrypted.

Closes: #17