### PR TITLE
Fix an error when exporting a file with an empty folder path

### DIFF
--- a/src/pck/PckFile.cpp
+++ b/src/pck/PckFile.cpp
@@ -416,7 +416,7 @@ bool PckFile::Extract(const std::string& outputPrefix, bool printExtracted)
         if(printExtracted)
             std::cout << "Extracting " << path << " to " << targetFile << "\n";
 
-        if(targetFolder.empty()) {
+        if(!targetFolder.empty()) {
             try {    
                 std::filesystem::create_directories(targetFolder);
             } catch(const std::filesystem::filesystem_error& e) {


### PR DESCRIPTION
I found that files that don't have a parent folder won't export, because an error will be thrown when there isn't a target folder. So I just added a quick check to see if targetFolder is empty, and skip creating parent directories if it is.